### PR TITLE
configure prettier

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,24 +1,23 @@
 env:
-  browser: true
-  es2024: true
-  node: true
-  webextensions: true
-extends: 
-  - standard
-  - plugin:unicorn/recommended
+    browser: true
+    es2024: true
+    node: true
+    webextensions: true
+extends:
+    - standard
+    - plugin:unicorn/recommended
+    - prettier
 parserOptions:
-  ecmaVersion: latest
-  sourceType: module
+    ecmaVersion: latest
+    sourceType: module
 plugins:
-  - unicorn
+    - unicorn
 globals:
-  PREVIEW_URL: readonly
+    PREVIEW_URL: readonly
 rules:
-  unicorn/better-regex: error
-  space-before-function-paren:
-    - error
-    -
-      anonymous: always
-      named: never
-      asyncArrow: always
-
+    unicorn/better-regex: error
+    space-before-function-paren:
+        - error
+        - anonymous: always
+          named: never
+          asyncArrow: always

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@types/chrome": "^0.0.262",
         "eslint": "^8.57.0",
+        "eslint-config-prettier": "^9.1.0",
         "eslint-config-standard": "^17.1.0",
         "eslint-formatter-codeframe": "^7.32.1",
         "eslint-plugin-import": "^2.29.1",
@@ -1044,6 +1045,18 @@
       },
       "peerDependencies": {
         "eslint": ">=6.0.0"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
+      "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-config-standard": {

--- a/package.json
+++ b/package.json
@@ -9,11 +9,18 @@
   "devDependencies": {
     "@types/chrome": "^0.0.262",
     "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
     "eslint-config-standard": "^17.1.0",
     "eslint-formatter-codeframe": "^7.32.1",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-n": "^16.6.2",
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-unicorn": "^51.0.1"
+  },
+  "prettier": {
+    "trailingComma": "es5",
+    "tabWidth": 4,
+    "semi": false,
+    "singleQuote": true
   }
 }


### PR DESCRIPTION
With this PR we configure prettier so that it works along with eslint. 

All the eslint rules that are overwritten by eslint take the prettier default. 